### PR TITLE
Add default layout metadata

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,13 +2,18 @@
 import "../styles/global.css";
 import Navbar from "../components/Navbar.astro";
 import WhatsAppButton from "../components/WhatsAppButton.astro";
+const { title, description } = Astro.props;
 ---
 
 <html lang="es">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title><slot name="title" /></title>
+    <title>{title || 'Imperial Net'}</title>
+    <meta
+      name="description"
+      content={description || 'Desarrollamos soluciones de software a medida'}
+    />
     <script type="module" src="/src/scripts/initAOS.js"></script>
     <!-- Bootstrap Icons (si aún no están cargados) -->
     <link

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,12 +9,12 @@ import ContactSection from "../components/ContactSection.astro";
 import CTASection from "../components/CTASection.astro";
 ---
 
-<Layout>
-  <HeroSection />
-  <SolutionsSection />
-  <AboutSection />
-  <CasesSection />
-  <BlogSection />
-  <ContactSection />
-  <CTASection />
+<Layout title="Imperial Net | Software a Medida" description="Automatizamos procesos y potenciamos tu PyME">
+    <HeroSection />
+    <SolutionsSection />
+    <AboutSection />
+    <CasesSection />
+    <BlogSection />
+    <ContactSection />
+    <CTASection />
 </Layout>


### PR DESCRIPTION
## Summary
- add default title and description to `BaseLayout`
- provide specific metadata for index page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e563990e0832c8ee75efaa1f66589