### PR TITLE
refactor: externalize WhatsApp phone

### DIFF
--- a/src/components/WhatsAppButton.astro
+++ b/src/components/WhatsAppButton.astro
@@ -1,7 +1,7 @@
 ---
 // src/components/WhatsAppButton.astro
-const phone = '5492923530179';
-const link = `https://wa.me/${phone}`;
+import { WHATSAPP_PHONE } from '../config';
+const link = `https://wa.me/${WHATSAPP_PHONE}`;
 ---
 
 <a href={link} class="whatsapp-float" target="_blank" rel="noopener noreferrer" aria-label="Chatear por WhatsApp">

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,1 @@
+export const WHATSAPP_PHONE = import.meta.env.PUBLIC_WHATSAPP_PHONE ?? '5492923530179';


### PR DESCRIPTION
## Summary
- centralize WhatsApp number in `src/config.ts`
- import number in `WhatsAppButton` and build link dynamically

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e58121eb0832cb7e60ecf9b6cbb66