### PR TITLE
refactor: centralize AOS init

### DIFF
--- a/public/js/initAOS.js
+++ b/public/js/initAOS.js
@@ -1,7 +1,0 @@
-import AOS from "aos";
-import "aos/dist/aos.css";
-
-AOS.init({
-      duration: 1000,
-      once: true
-    });

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import "../styles/global.css";
 import Navbar from "../components/Navbar.astro";
 import WhatsAppButton from "../components/WhatsAppButton.astro";
+import initAOS from "../scripts/initAOS.js?url";
 const { title, description } = Astro.props;
 ---
 
@@ -14,7 +15,7 @@ const { title, description } = Astro.props;
       name="description"
       content={description || 'Desarrollamos soluciones de software a medida'}
     />
-    <script type="module" src="/src/scripts/initAOS.js"></script>
+    <script type="module" src={initAOS}></script>
     <!-- Bootstrap Icons (si aún no están cargados) -->
     <link
       rel="stylesheet"

--- a/src/scripts/initAOS.js
+++ b/src/scripts/initAOS.js
@@ -1,4 +1,8 @@
 import AOS from "aos";
 import "aos/dist/aos.css";
 
-AOS.init();
+// Initialize AOS with default settings shared across the site
+AOS.init({
+  duration: 1000,
+  once: true,
+});


### PR DESCRIPTION
## Summary
- remove duplicate AOS init script
- load AOS init from BaseLayout with shared config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e59fa6ae4832c9b10d26145d622b1