### PR TITLE
Add blog pages with initial posts

### DIFF
--- a/src/components/BlogSection.astro
+++ b/src/components/BlogSection.astro
@@ -11,7 +11,7 @@
             <p class="card-text text-white">
               Descubrí los beneficios tangibles de incorporar tecnología en tu negocio: eficiencia, control y crecimiento.
             </p>
-            <a href="#" class="text-white text-decoration-underline">Leer más</a>
+              <a href="/blog/por-que-digitalizar-tu-empresa" class="text-white text-decoration-underline">Leer más</a>
           </div>
         </div>
       </div>
@@ -24,7 +24,7 @@
             <p class="card-text text-white">
               Casos reales que muestran cómo reducir costos, minimizar errores y escalar procesos con soluciones simples.
             </p>
-            <a href="#" class="text-white text-decoration-underline">Leer más</a>
+              <a href="/blog/automatizacion-para-pymes" class="text-white text-decoration-underline">Leer más</a>
           </div>
         </div>
       </div>
@@ -37,7 +37,7 @@
             <p class="card-text text-white">
               Conocé qué factores tenés que considerar al desarrollar o contratar un sistema hecho para tu negocio.
             </p>
-            <a href="#" class="text-white text-decoration-underline">Leer más</a>
+              <a href="/blog/como-elegir-un-software-a-medida" class="text-white text-decoration-underline">Leer más</a>
           </div>
         </div>
       </div>

--- a/src/pages/blog/automatizacion-para-pymes.md
+++ b/src/pages/blog/automatizacion-para-pymes.md
@@ -1,0 +1,28 @@
+---
+layout: ../../layouts/BaseLayout.astro
+title: "Automatización para PyMEs: cómo reducir costos y errores"
+description: "Ejemplos simples para ahorrar tiempo y evitar equivocaciones."
+---
+
+<section class="py-5 text-white">
+<div class="container">
+
+# Automatización para PyMEs: cómo reducir costos y errores
+
+## Liberá tiempo para lo que importa
+Las pequeñas empresas suelen tener pocos empleados. Repetir tareas como enviar recordatorios o registrar pagos consume horas valiosas. Con la automatización, esas acciones se ejecutan solas y tu equipo se enfoca en vender y atender mejor.
+
+## Un caso simple: la facturación automática
+Si administrás un gimnasio con muchas cuotas mensuales, emitir facturas una por una es agotador. Un sistema automatizado genera los comprobantes y los envía por correo en segundos. Además, registra quién pagó y quién no, sin que tengas que revisar planillas.
+
+## Menos errores, más control
+Cuando los procesos siguen reglas claras, la posibilidad de equivocarse disminuye. Un software que descuenta productos del inventario cada vez que se realiza una venta evita confusiones. También podés ver reportes que muestran tus productos más vendidos y detectar qué necesita atención.
+
+## Ahorro económico tangible
+Cada error corregido cuesta dinero. Al automatizar tu agenda o tus pedidos, reducís las fallas y los gastos extra. Un consultorio que envía recordatorios automáticos, por ejemplo, reduce las ausencias y aprovecha mejor cada turno.
+
+## Tu negocio, siempre en movimiento
+La automatización te permite crecer sin complicarte. Podés agregar nuevos servicios, abrir un canal de ventas en línea o responder consultas fuera del horario laboral. Si querés implementar herramientas que se adapten a tu PyME, hablá con nosotros. Te ayudamos a que cada proceso funcione solo.
+
+</div>
+</section>

--- a/src/pages/blog/como-elegir-un-software-a-medida.md
+++ b/src/pages/blog/como-elegir-un-software-a-medida.md
@@ -1,0 +1,28 @@
+---
+layout: ../../layouts/BaseLayout.astro
+title: "Cómo elegir un software a medida sin complicaciones"
+description: "Pasos simples para encontrar la herramienta ideal para tu negocio."
+---
+
+<section class="py-5 text-white">
+<div class="container">
+
+# Cómo elegir un software a medida sin complicaciones
+
+## Entendé tus necesidades antes de buscar
+Hacé una lista de los procesos que querés mejorar: ventas, stock, turnos. Cuanto más claro tengas el objetivo, más fácil será hablar con un proveedor o comparar opciones.
+
+## Buscá flexibilidad y crecimiento
+Tu negocio cambia con el tiempo. Elegí un sistema que permita agregar usuarios, integrar nuevas funciones o conectarse con otras herramientas. Así no tendrás que empezar de cero cada vez que crezcas.
+
+## Probá antes de decidir
+Pedí una demo o un prototipo. Usalo unos días con tu equipo y pediles comentarios. Si todos entienden cómo funciona y se sienten cómodos, estás en el camino correcto.
+
+## Soporte y capacitación
+Un buen software viene acompañado de personas que te ayuden. Asegurate de que el proveedor ofrezca capacitación y una vía rápida de contacto para resolver dudas.
+
+## Elegí con confianza
+Tomarse el tiempo para evaluar opciones evita gastos innecesarios. Si querés un software que se adapte a tu PyME sin dolores de cabeza, hablá con nosotros. Te acompañamos de principio a fin para que la tecnología se vuelva tu aliada.
+
+</div>
+</section>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,25 @@
+---
+import Layout from "../../layouts/BaseLayout.astro";
+const posts = await Astro.glob("./*.md");
+---
+
+<Layout title="Blog | Imperial Net" description="Consejos simples sobre digitalización y software para PyMEs">
+  <section class="py-5 text-white">
+    <div class="container">
+      <h1 class="mb-4">Blog</h1>
+      <div class="row g-4">
+        {posts.map((post) => (
+          <div class="col-md-6 col-lg-4">
+            <div class="card h-100 bg-secondary border-0 shadow-sm">
+              <div class="card-body">
+                <h5 class="card-title fw-semibold text-white">{post.frontmatter.title}</h5>
+                <p class="card-text text-white">{post.frontmatter.description}</p>
+                <a href={post.url} class="text-white text-decoration-underline">Leer más</a>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+</Layout>

--- a/src/pages/blog/por-que-digitalizar-tu-empresa.md
+++ b/src/pages/blog/por-que-digitalizar-tu-empresa.md
@@ -1,0 +1,28 @@
+---
+layout: ../../layouts/BaseLayout.astro
+title: "Por qué digitalizar tu empresa es una inversión rentable"
+description: "Descubrí cómo simplificar tareas y ahorrar dinero al llevar tus procesos a la pantalla."
+---
+
+<section class="py-5 text-white">
+<div class="container">
+
+# Por qué digitalizar tu empresa es una inversión rentable
+
+## La eficiencia empieza con un clic
+Digitalizar no es sólo usar la computadora. Se trata de organizar tus procesos para que sean más rápidos y confiables. Imaginá un negocio que lleva sus ventas en cuadernos. Cada día alguien debe revisar los apuntes, sumar números y copiar datos. Un sistema digital registra todo al instante y evita esa tarea repetitiva.
+
+## Ahorro de tiempo y costos
+Las tareas manuales consumen horas que podrías dedicar a tus clientes. Si automatizás la emisión de facturas o el control de stock, reducís errores y evitás gastos por productos perdidos o facturas mal emitidas. El tiempo libre lo usás para mejorar el servicio o planear nuevas ofertas.
+
+## Datos en tiempo real para decidir mejor
+Con la información actualizada podés saber qué productos se venden más, cuándo comprar insumos o qué servicios ofrecer. Ya no dependés de la memoria o de revisar papeles. Las decisiones se toman con datos claros y en el momento justo.
+
+## Imagen profesional frente al cliente
+Un sitio web donde tus clientes puedan consultar precios, hacer pedidos o pedir soporte muestra seriedad. La digitalización transmite confianza y te diferencia de quienes siguen con procesos desordenados.
+
+## Empezá de a poco
+No hace falta digitalizar todo hoy. Elegí un proceso simple, como el registro de ventas, y buscá una herramienta que se adapte a tu realidad. Si querés que te orientemos sobre el paso siguiente, contactanos. Estamos listos para ayudarte a que tu negocio crezca con tecnología.
+
+</div>
+</section>


### PR DESCRIPTION
## Summary
- add `/blog` index that dynamically lists markdown posts
- write three starter posts explaining digitalización, automatización y software a medida
- link blog cards on home page to the new articles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e558ea210832c9b6bb5ef3e37a4dc